### PR TITLE
Reduce main-thread CPU during GUI interaction (especially on low-power devices)

### DIFF
--- a/effetune.css
+++ b/effetune.css
@@ -522,6 +522,11 @@ input[type="checkbox"] {
     border-radius: 4px;
     transition: background-color 0.2s;
     width: auto; /* Changed from fixed width to auto */
+    /* Confine layout/style/paint inside each plugin card so scrolling does
+       not force the browser to re-evaluate hit-test and paint for plugins
+       outside the visible viewport. Significantly reduces main-thread cost
+       during scrolling on low-power hardware. */
+    contain: layout style paint;
 }
 
 /* Column control buttons */

--- a/js/ui/pipeline/pipeline-item-builder.js
+++ b/js/ui/pipeline/pipeline-item-builder.js
@@ -832,15 +832,11 @@ export class PipelineItemBuilder {
         for (let i = startIdx + 1; i < pipeline.length; i++) {
             const p = pipeline[i];
             if (p.constructor.name === 'SectionPlugin') break;
-            if (typeof p.startAnimation !== 'function' ||
-                typeof p.stopAnimation !== 'function') {
-                continue;
-            }
-            if (sectionOn) {
-                // Resume only if the plugin itself is also enabled.
-                if (p.enabled) p.startAnimation();
-            } else {
-                p.stopAnimation();
+            // Update the cached section-enabled state so that subsequent
+            // startAnimation() calls (e.g. from the IntersectionObserver
+            // when the canvas scrolls back into view) respect it.
+            if (typeof p._setSectionEnabled === 'function') {
+                p._setSectionEnabled(sectionOn);
             }
         }
     }

--- a/js/ui/pipeline/pipeline-item-builder.js
+++ b/js/ui/pipeline/pipeline-item-builder.js
@@ -171,13 +171,20 @@ export class PipelineItemBuilder {
             // disabled, freeing main-thread CPU on low-power hardware).
             plugin.setEnabled(!plugin.enabled);
             toggle.classList.toggle('off', !plugin.enabled);
-            
+
+            // Toggling a Section's ON also bypasses every plugin inside it
+            // on the worklet side. Mirror that on the main thread so the
+            // analyzers inside the section pause their redraw loops too.
+            if (plugin.constructor.name === 'SectionPlugin') {
+                this._propagateSectionEnabledToAnimations(plugin);
+            }
+
             // Use the common selection function
             this.pipelineCore.handlePluginSelection(plugin, e);
-            
+
             // Update worklet directly without rebuilding pipeline
             this.pipelineCore.updateWorkletPlugin(plugin);
-            
+
             // Update UI display state for all plugins that might be affected by this change
             this.pipelineCore.updateAllPluginDisplayState();
             
@@ -809,5 +816,32 @@ export class PipelineItemBuilder {
                 ? (window.uiManager ? window.uiManager.t('ui.title.collapse') : 'Click to collapse')
                 : (window.uiManager ? window.uiManager.t('ui.title.expand') : 'Click to expand');
         });
+    }
+
+    // When a Section's ON/OFF state changes, pause or resume the per-frame
+    // redraw loop of every plugin that belongs to that section. A section
+    // spans from the toggled Section plugin up to (but not including) the
+    // next Section plugin in the pipeline, matching the worklet's
+    // section-active gating in plugins/audio-processor.js.
+    _propagateSectionEnabledToAnimations(sectionPlugin) {
+        const pipeline = this.audioManager && this.audioManager.pipeline;
+        if (!pipeline) return;
+        const startIdx = pipeline.indexOf(sectionPlugin);
+        if (startIdx < 0) return;
+        const sectionOn = sectionPlugin.enabled;
+        for (let i = startIdx + 1; i < pipeline.length; i++) {
+            const p = pipeline[i];
+            if (p.constructor.name === 'SectionPlugin') break;
+            if (typeof p.startAnimation !== 'function' ||
+                typeof p.stopAnimation !== 'function') {
+                continue;
+            }
+            if (sectionOn) {
+                // Resume only if the plugin itself is also enabled.
+                if (p.enabled) p.startAnimation();
+            } else {
+                p.stopAnimation();
+            }
+        }
     }
 }

--- a/js/ui/pipeline/pipeline-item-builder.js
+++ b/js/ui/pipeline/pipeline-item-builder.js
@@ -166,7 +166,10 @@ export class PipelineItemBuilder {
             : 'Enable or disable effect';
         toggle.classList.toggle('off', !plugin.enabled);
         toggle.onclick = (e) => {
-            plugin.enabled = !plugin.enabled;
+            // Go through setEnabled() so plugins can react to the transition
+            // (e.g. analyzer plugins pause their per-frame redraw loop when
+            // disabled, freeing main-thread CPU on low-power hardware).
+            plugin.setEnabled(!plugin.enabled);
             toggle.classList.toggle('off', !plugin.enabled);
             
             // Use the common selection function

--- a/js/utils/serialization-utils.js
+++ b/js/utils/serialization-utils.js
@@ -144,7 +144,7 @@ export function applySerializedState(plugin, state) {
         plugin.name = state.nm;
         
         if (state.en !== undefined) {
-            plugin.enabled = state.en;
+            plugin.setEnabled(state.en);
         }
         
         if (state.ib !== undefined) {
@@ -173,7 +173,7 @@ export function applySerializedState(plugin, state) {
         plugin.name = state.name;
         
         if (state.enabled !== undefined) {
-            plugin.enabled = state.enabled;
+            plugin.setEnabled(state.enabled);
         }
         
         if (state.inputBus !== undefined) {

--- a/plugins/analyzer/level_meter.js
+++ b/plugins/analyzer/level_meter.js
@@ -281,6 +281,7 @@ class LevelMeterPlugin extends PluginBase {
     }
 
     startAnimation() {
+        if (!this.enabled) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/analyzer/level_meter.js
+++ b/plugins/analyzer/level_meter.js
@@ -281,7 +281,7 @@ class LevelMeterPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled) return;
+        if (!this.enabled || !this._sectionEnabled) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/analyzer/oscilloscope.js
+++ b/plugins/analyzer/oscilloscope.js
@@ -550,6 +550,7 @@ class OscilloscopePlugin extends PluginBase {
 
     startAnimation() {
         if (this.animationFrameId) return;
+        if (!this.enabled) return; // Don't start the redraw loop while disabled.
 
         const animate = () => {
             if (!this.isVisible) {

--- a/plugins/analyzer/oscilloscope.js
+++ b/plugins/analyzer/oscilloscope.js
@@ -550,7 +550,7 @@ class OscilloscopePlugin extends PluginBase {
 
     startAnimation() {
         if (this.animationFrameId) return;
-        if (!this.enabled) return; // Don't start the redraw loop while disabled.
+        if (!this.enabled || !this._sectionEnabled) return; // Skip if disabled or section is off.
 
         const animate = () => {
             if (!this.isVisible) {

--- a/plugins/analyzer/spectrogram.js
+++ b/plugins/analyzer/spectrogram.js
@@ -249,7 +249,7 @@ class SpectrogramPlugin extends PluginBase {
 
     process(message) {
         if (!message?.measurements?.buffer) return;
-        if (!this.enabled) return;
+        if (!this.enabled || !this._sectionEnabled) return;
         if (!this.spectrogramBuffer) return; // Check if spectrogramBuffer exists
 
         const fftSize = 1 << this.pt;
@@ -424,7 +424,7 @@ class SpectrogramPlugin extends PluginBase {
     }
 
     handleIntersect(entries) { /* ... (same as original) ... */ entries.forEach(entry => {this.isVisible = entry.isIntersecting; if (this.isVisible) {this.startAnimation();} else {this.stopAnimation();}}); }
-    startAnimation() { /* ... (same as original) ... */ if (this.animationFrameId) return; if (!this.enabled) return; const animate = () => {if (!this.isVisible) {this.stopAnimation(); return;} this.drawGraph(); this.animationFrameId = requestAnimationFrame(animate);}; animate(); }
+    startAnimation() { /* ... (same as original) ... */ if (this.animationFrameId) return; if (!this.enabled || !this._sectionEnabled) return; const animate = () => {if (!this.isVisible) {this.stopAnimation(); return;} this.drawGraph(); this.animationFrameId = requestAnimationFrame(animate);}; animate(); }
     stopAnimation() { /* ... (same as original) ... */ if (this.animationFrameId) {cancelAnimationFrame(this.animationFrameId); this.animationFrameId = null;} }
     cleanup() { /* ... (mostly same, ensure listeners are correctly removed if stored differently) ... */
         this.stopAnimation();

--- a/plugins/analyzer/spectrogram.js
+++ b/plugins/analyzer/spectrogram.js
@@ -424,7 +424,7 @@ class SpectrogramPlugin extends PluginBase {
     }
 
     handleIntersect(entries) { /* ... (same as original) ... */ entries.forEach(entry => {this.isVisible = entry.isIntersecting; if (this.isVisible) {this.startAnimation();} else {this.stopAnimation();}}); }
-    startAnimation() { /* ... (same as original) ... */ if (this.animationFrameId) return; const animate = () => {if (!this.isVisible) {this.stopAnimation(); return;} this.drawGraph(); this.animationFrameId = requestAnimationFrame(animate);}; animate(); }
+    startAnimation() { /* ... (same as original) ... */ if (this.animationFrameId) return; if (!this.enabled) return; const animate = () => {if (!this.isVisible) {this.stopAnimation(); return;} this.drawGraph(); this.animationFrameId = requestAnimationFrame(animate);}; animate(); }
     stopAnimation() { /* ... (same as original) ... */ if (this.animationFrameId) {cancelAnimationFrame(this.animationFrameId); this.animationFrameId = null;} }
     cleanup() { /* ... (mostly same, ensure listeners are correctly removed if stored differently) ... */
         this.stopAnimation();

--- a/plugins/analyzer/spectrum_analyzer.js
+++ b/plugins/analyzer/spectrum_analyzer.js
@@ -363,6 +363,7 @@ class SpectrumAnalyzerPlugin extends PluginBase {
 
     startAnimation() {
         if (this.animationFrameId) return;
+        if (!this.enabled) return; // Don't start the redraw loop while disabled.
         const animate = () => {
             if (!this.isVisible) {
                 this.stopAnimation();

--- a/plugins/analyzer/spectrum_analyzer.js
+++ b/plugins/analyzer/spectrum_analyzer.js
@@ -363,7 +363,7 @@ class SpectrumAnalyzerPlugin extends PluginBase {
 
     startAnimation() {
         if (this.animationFrameId) return;
-        if (!this.enabled) return; // Don't start the redraw loop while disabled.
+        if (!this.enabled || !this._sectionEnabled) return; // Skip if disabled or section is off.
         const animate = () => {
             if (!this.isVisible) {
                 this.stopAnimation();

--- a/plugins/analyzer/stereo_meter.js
+++ b/plugins/analyzer/stereo_meter.js
@@ -256,7 +256,7 @@ class StereoMeterPlugin extends PluginBase {
   }
 
   startAnimation() {
-      if (!this.enabled) return;
+      if (!this.enabled || !this._sectionEnabled) return;
     if (this.animationFrameId) return;
 
     const animate = () => {

--- a/plugins/analyzer/stereo_meter.js
+++ b/plugins/analyzer/stereo_meter.js
@@ -256,6 +256,7 @@ class StereoMeterPlugin extends PluginBase {
   }
 
   startAnimation() {
+      if (!this.enabled) return;
     if (this.animationFrameId) return;
 
     const animate = () => {

--- a/plugins/dynamics/auto_leveler.js
+++ b/plugins/dynamics/auto_leveler.js
@@ -381,7 +381,7 @@ class AutoLevelerPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled) return;
+        if (!this.enabled || !this._sectionEnabled) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/dynamics/auto_leveler.js
+++ b/plugins/dynamics/auto_leveler.js
@@ -381,6 +381,7 @@ class AutoLevelerPlugin extends PluginBase {
     }
 
     startAnimation() {
+        if (!this.enabled) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/dynamics/compressor.js
+++ b/plugins/dynamics/compressor.js
@@ -585,7 +585,7 @@ class CompressorPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled) return;
+        if (!this.enabled || !this._sectionEnabled) return;
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;

--- a/plugins/dynamics/compressor.js
+++ b/plugins/dynamics/compressor.js
@@ -585,6 +585,7 @@ class CompressorPlugin extends PluginBase {
     }
 
     startAnimation() {
+        if (!this.enabled) return;
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;

--- a/plugins/dynamics/compressor.js
+++ b/plugins/dynamics/compressor.js
@@ -13,6 +13,12 @@ class CompressorPlugin extends PluginBase {
         this.lastProcessTime = performance.now() / 1000;
         this.animationFrameId = null;
         this._hasMessageHandler = false;
+        // Visibility / IntersectionObserver setup so the redraw loop can be
+        // paused while the canvas is scrolled out of view. Replaces a
+        // per-frame getBoundingClientRect() call which forces synchronous
+        // layout on the main thread.
+        this.isVisible = true;
+        this.observer = null;
 
         this._setupMessageHandler();
 
@@ -579,6 +585,19 @@ class CompressorPlugin extends PluginBase {
         graphContainer.appendChild(canvas);
         container.appendChild(graphContainer);
 
+        // Pause the redraw loop while the canvas is off-screen.
+        this.observer = new IntersectionObserver(entries => {
+            for (const entry of entries) {
+                this.isVisible = entry.isIntersecting;
+                if (this.isVisible) {
+                    this.startAnimation();
+                } else {
+                    this.stopAnimation();
+                }
+            }
+        });
+        this.observer.observe(this.canvas);
+
         this.updateTransferGraph();
         this.startAnimation();
         return container;
@@ -599,17 +618,8 @@ class CompressorPlugin extends PluginBase {
                 this.cleanup();  // Stop animation if canvas is removed
                 return;
             }
-            
-            // Check if the element is in the viewport before updating
-            const rect = this.canvas.getBoundingClientRect();
-            const isVisible = (
-                rect.top < window.innerHeight &&
-                rect.bottom > 0 &&
-                rect.left < window.innerWidth &&
-                rect.right > 0
-            );
-            
-            if (isVisible) {
+
+            if (this.isVisible) {
                 // Check if we need to update the graph
                 const needsUpdate = this.needsGraphUpdate(lastGraphState);
                 if (needsUpdate) {
@@ -666,6 +676,10 @@ class CompressorPlugin extends PluginBase {
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;
+        }
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
         }
         this.gr = 0;
         this.lastProcessTime = performance.now() / 1000;

--- a/plugins/dynamics/expander.js
+++ b/plugins/dynamics/expander.js
@@ -592,7 +592,7 @@ class ExpanderPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled) return;
+        if (!this.enabled || !this._sectionEnabled) return;
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;

--- a/plugins/dynamics/expander.js
+++ b/plugins/dynamics/expander.js
@@ -592,6 +592,7 @@ class ExpanderPlugin extends PluginBase {
     }
 
     startAnimation() {
+        if (!this.enabled) return;
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;

--- a/plugins/dynamics/expander.js
+++ b/plugins/dynamics/expander.js
@@ -13,6 +13,8 @@ class ExpanderPlugin extends PluginBase {
         this.lastProcessTime = performance.now() / 1000;
         this.animationFrameId = null;
         this._hasMessageHandler = false;
+        this.isVisible = true;
+        this.observer = null;
 
         this._setupMessageHandler();
 
@@ -586,6 +588,18 @@ class ExpanderPlugin extends PluginBase {
         graphContainer.appendChild(canvas);
         container.appendChild(graphContainer);
 
+        this.observer = new IntersectionObserver(entries => {
+            for (const entry of entries) {
+                this.isVisible = entry.isIntersecting;
+                if (this.isVisible) {
+                    this.startAnimation();
+                } else {
+                    this.stopAnimation();
+                }
+            }
+        });
+        this.observer.observe(this.canvas);
+
         this.updateTransferGraph();
         this.startAnimation();
         return container;
@@ -606,16 +620,9 @@ class ExpanderPlugin extends PluginBase {
                 this.cleanup();  // Stop animation if canvas is removed
                 return;
             }
-            
-            // Check if the element is in the viewport before updating
-            const rect = this.canvas.getBoundingClientRect();
-            const isVisible = (
-                rect.top < window.innerHeight &&
-                rect.bottom > 0 &&
-                rect.left < window.innerWidth &&
-                rect.right > 0
-            );
-            
+
+            const isVisible = this.isVisible;
+
             if (isVisible) {
                 // Check if we need to update the graph
                 const needsUpdate = this.needsGraphUpdate(lastGraphState);
@@ -673,6 +680,10 @@ class ExpanderPlugin extends PluginBase {
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;
+        }
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
         }
         this.gb = 0;
         this.lastProcessTime = performance.now() / 1000;

--- a/plugins/dynamics/gate.js
+++ b/plugins/dynamics/gate.js
@@ -13,6 +13,8 @@ class GatePlugin extends PluginBase {
         this.lastProcessTime = performance.now() / 1000;
         this.animationFrameId = null;
         this._hasMessageHandler = false;
+        this.isVisible = true;
+        this.observer = null;
 
         this._setupMessageHandler();
 
@@ -715,6 +717,18 @@ class GatePlugin extends PluginBase {
         graphContainer.appendChild(canvas);
         container.appendChild(graphContainer);
 
+        this.observer = new IntersectionObserver(entries => {
+            for (const entry of entries) {
+                this.isVisible = entry.isIntersecting;
+                if (this.isVisible) {
+                    this.startAnimation();
+                } else {
+                    this.stopAnimation();
+                }
+            }
+        });
+        this.observer.observe(this.canvas);
+
         this.updateTransferGraph();
         this.startAnimation();
         return container;
@@ -735,16 +749,9 @@ class GatePlugin extends PluginBase {
                 this.cleanup();  // Stop animation if canvas is removed
                 return;
             }
-            
-            // Check if the element is in the viewport before updating
-            const rect = this.canvas.getBoundingClientRect();
-            const isVisible = (
-                rect.top < window.innerHeight &&
-                rect.bottom > 0 &&
-                rect.left < window.innerWidth &&
-                rect.right > 0
-            );
-            
+
+            const isVisible = this.isVisible;
+
             if (isVisible) {
                 // Check if we need to update the graph
                 const needsUpdate = this.needsGraphUpdate(lastGraphState);
@@ -802,6 +809,10 @@ class GatePlugin extends PluginBase {
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;
+        }
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
         }
         this.gr = 0;
         this.lastProcessTime = performance.now() / 1000;

--- a/plugins/dynamics/gate.js
+++ b/plugins/dynamics/gate.js
@@ -721,6 +721,7 @@ class GatePlugin extends PluginBase {
     }
 
     startAnimation() {
+        if (!this.enabled) return;
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;

--- a/plugins/dynamics/gate.js
+++ b/plugins/dynamics/gate.js
@@ -721,7 +721,7 @@ class GatePlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled) return;
+        if (!this.enabled || !this._sectionEnabled) return;
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;

--- a/plugins/dynamics/multiband_compressor.js
+++ b/plugins/dynamics/multiband_compressor.js
@@ -1206,6 +1206,7 @@ class MultibandCompressorPlugin extends PluginBase {
   }
 
   startAnimation() {
+      if (!this.enabled) return;
     if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId);
     
     let lastGraphState = null;

--- a/plugins/dynamics/multiband_compressor.js
+++ b/plugins/dynamics/multiband_compressor.js
@@ -1206,7 +1206,7 @@ class MultibandCompressorPlugin extends PluginBase {
   }
 
   startAnimation() {
-      if (!this.enabled) return;
+      if (!this.enabled || !this._sectionEnabled) return;
     if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId);
     
     let lastGraphState = null;

--- a/plugins/dynamics/multiband_compressor.js
+++ b/plugins/dynamics/multiband_compressor.js
@@ -20,6 +20,8 @@ class MultibandCompressorPlugin extends PluginBase {
     this.selectedBand = 0;
     this.lastProcessTime = performance.now() / 1000;
     this.animationFrameId = null;
+    this.isVisible = true;
+    this.observer = null;
 
     // Register the processor code (returned as a string)
     this.registerProcessor(this.getProcessorCode());
@@ -1199,6 +1201,19 @@ class MultibandCompressorPlugin extends PluginBase {
 
     // Cache main canvas reference for animation updates
     this.canvas = container.querySelector('.multiband-compressor-band-graph.active canvas');
+
+    this.observer = new IntersectionObserver(entries => {
+      for (const entry of entries) {
+        this.isVisible = entry.isIntersecting;
+        if (this.isVisible) {
+          this.startAnimation();
+        } else {
+          this.stopAnimation();
+        }
+      }
+    });
+    this.observer.observe(container);
+
     this.updateTransferGraphs();
     this.startAnimation();
 
@@ -1218,17 +1233,8 @@ class MultibandCompressorPlugin extends PluginBase {
         this.cleanup();  // Stop animation if container is removed
         return;
       }
-      
-      // Check if the element is in the viewport before updating
-      const rect = container.getBoundingClientRect();
-      const isVisible = (
-        rect.top < window.innerHeight &&
-        rect.bottom > 0 &&
-        rect.left < window.innerWidth &&
-        rect.right > 0
-      );
-      
-      if (isVisible) {
+
+      if (this.isVisible) {
         // Check if we need to update the graph
         const needsUpdate = this.needsGraphUpdate(lastGraphState);
         if (needsUpdate) {
@@ -1282,6 +1288,10 @@ class MultibandCompressorPlugin extends PluginBase {
     if (this.animationFrameId) {
       cancelAnimationFrame(this.animationFrameId);
       this.animationFrameId = null;
+    }
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
     }
     this.canvas = null;  // Clear canvas reference
     this.bands.forEach(band => band.gr = 0);

--- a/plugins/dynamics/multiband_expander.js
+++ b/plugins/dynamics/multiband_expander.js
@@ -1085,6 +1085,7 @@ class MultibandExpanderPlugin extends PluginBase {
   }
 
   startAnimation() {
+      if (!this.enabled) return;
     if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId);
 
     let lastGraphState = null;

--- a/plugins/dynamics/multiband_expander.js
+++ b/plugins/dynamics/multiband_expander.js
@@ -24,6 +24,8 @@ class MultibandExpanderPlugin extends PluginBase {
     this.selectedBand = 0;
     this.lastProcessTime = performance.now() / 1000;
     this.animationFrameId = null;
+    this.isVisible = true;
+    this.observer = null;
 
     // Register the processor code (returned as a string)
     this.registerProcessor(this.getProcessorCode());
@@ -1078,6 +1080,19 @@ class MultibandExpanderPlugin extends PluginBase {
     container.appendChild(graphsContainer);
 
     this.canvas = container.querySelector('.multiband-expander-band-graph.active canvas');
+
+    this.observer = new IntersectionObserver(entries => {
+      for (const entry of entries) {
+        this.isVisible = entry.isIntersecting;
+        if (this.isVisible) {
+          this.startAnimation();
+        } else {
+          this.stopAnimation();
+        }
+      }
+    });
+    this.observer.observe(container);
+
     this.updateTransferGraphs();
     this.startAnimation();
 
@@ -1097,15 +1112,7 @@ class MultibandExpanderPlugin extends PluginBase {
         return;
       }
 
-      const rect = container.getBoundingClientRect();
-      const isVisible = (
-        rect.top < window.innerHeight &&
-        rect.bottom > 0 &&
-        rect.left < window.innerWidth &&
-        rect.right > 0
-      );
-
-      if (isVisible) {
+      if (this.isVisible) {
         const needsUpdate = this.needsGraphUpdate(lastGraphState);
         if (needsUpdate) {
           this.updateTransferGraphs();
@@ -1149,6 +1156,10 @@ class MultibandExpanderPlugin extends PluginBase {
     if (this.animationFrameId) {
       cancelAnimationFrame(this.animationFrameId);
       this.animationFrameId = null;
+    }
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
     }
     this.canvas = null;
     this.bands.forEach(band => band.gb = 0);

--- a/plugins/dynamics/multiband_expander.js
+++ b/plugins/dynamics/multiband_expander.js
@@ -1085,7 +1085,7 @@ class MultibandExpanderPlugin extends PluginBase {
   }
 
   startAnimation() {
-      if (!this.enabled) return;
+      if (!this.enabled || !this._sectionEnabled) return;
     if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId);
 
     let lastGraphState = null;

--- a/plugins/dynamics/multiband_transient.js
+++ b/plugins/dynamics/multiband_transient.js
@@ -560,7 +560,7 @@ class MultibandTransientPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled) return;
+        if (!this.enabled || !this._sectionEnabled) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/dynamics/multiband_transient.js
+++ b/plugins/dynamics/multiband_transient.js
@@ -560,6 +560,7 @@ class MultibandTransientPlugin extends PluginBase {
     }
 
     startAnimation() {
+        if (!this.enabled) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/dynamics/power_amp_sag.js
+++ b/plugins/dynamics/power_amp_sag.js
@@ -291,6 +291,7 @@ class PowerAmpSagPlugin extends PluginBase {
     }
     
     startAnimation() {
+        if (!this.enabled) return;
         if (this.animationFrameId) return;
         
         const animate = () => {

--- a/plugins/dynamics/power_amp_sag.js
+++ b/plugins/dynamics/power_amp_sag.js
@@ -291,7 +291,7 @@ class PowerAmpSagPlugin extends PluginBase {
     }
     
     startAnimation() {
-        if (!this.enabled) return;
+        if (!this.enabled || !this._sectionEnabled) return;
         if (this.animationFrameId) return;
         
         const animate = () => {

--- a/plugins/dynamics/transient_shaper.js
+++ b/plugins/dynamics/transient_shaper.js
@@ -160,7 +160,7 @@ class TransientShaperPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled) return;
+        if (!this.enabled || !this._sectionEnabled) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/dynamics/transient_shaper.js
+++ b/plugins/dynamics/transient_shaper.js
@@ -160,6 +160,7 @@ class TransientShaperPlugin extends PluginBase {
     }
 
     startAnimation() {
+        if (!this.enabled) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/eq/five_band_dynamic_eq.js
+++ b/plugins/eq/five_band_dynamic_eq.js
@@ -1146,7 +1146,7 @@ class FiveBandDynamicEQ extends PluginBase {
     // --- Animation Loop for Dynamic Graph ---
     startAnimation() {
         if (this.animationFrameId) return; // Already running
-        if (!this.enabled) return; // Don't start the redraw loop while disabled.
+        if (!this.enabled || !this._sectionEnabled) return; // Skip if disabled or section is off.
         const animate = () => {
             this._drawGraph(); // Redraw graph with potentially updated (dynamic) data
             this.animationFrameId = requestAnimationFrame(animate);

--- a/plugins/eq/five_band_dynamic_eq.js
+++ b/plugins/eq/five_band_dynamic_eq.js
@@ -876,11 +876,20 @@ class FiveBandDynamicEQ extends PluginBase {
         const maxGain = 12;      // dB
         const gainRange = maxGain - minGain;
 
+        // Pre-computed constants for log-scale frequency mapping (used by
+        // every curve and grid-line below). Recomputed only if not yet set.
+        if (this._logMinFreq === undefined) {
+            this._logMinFreq = Math.log10(minFreq);
+            this._logFreqSpan = Math.log10(maxFreq) - this._logMinFreq;
+        }
+        const logMinFreq = this._logMinFreq;
+        const logFreqSpan = this._logFreqSpan;
+
         // --- Frequency Grid Lines (Vertical) ---
         const freqLines = [20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000];
         freqLines.forEach(freq => {
             // Calculate x position on a logarithmic scale
-            const x = width * (Math.log10(freq) - Math.log10(minFreq)) / (Math.log10(maxFreq) - Math.log10(minFreq));
+            const x = width * (Math.log10(freq) - logMinFreq) / logFreqSpan;
             // Draw the vertical line
             ctx.beginPath();
             ctx.moveTo(x, 0);
@@ -909,12 +918,24 @@ class FiveBandDynamicEQ extends PluginBase {
         });
 
         // --- Calculate Frequency Points for Curve Plotting ---
-        const numPoints = 500; // Number of points for smooth curves
-        const freqPoints = new Array(numPoints + 1).fill(0).map((_, i) => {
-            // Generate points logarithmically spaced across the frequency range
-            const t = i / numPoints;
-            return minFreq * Math.pow(maxFreq / minFreq, t);
-        });
+        // The frequency axis is static (minFreq/maxFreq are constants), so the
+        // sample-frequency array, its log values, and the constant zero-gains
+        // fallback array are all built once and reused. Previously, ~1000
+        // Float entries were freshly allocated every frame (60 Hz), which was
+        // the dominant main-thread allocation site on low-power hardware.
+        const numPoints = 500;
+        if (!this._freqPoints || this._freqPoints.length !== numPoints + 1) {
+            const fp = new Float64Array(numPoints + 1);
+            const ratio = maxFreq / minFreq;
+            for (let i = 0; i <= numPoints; i++) {
+                fp[i] = minFreq * Math.pow(ratio, i / numPoints);
+            }
+            this._freqPoints = fp;
+        }
+        if (!this._zeroGains || this._zeroGains.length !== this.numBands) {
+            this._zeroGains = new Float64Array(this.numBands);
+        }
+        const freqPoints = this._freqPoints;
 
         // --- Draw Static Curves for Selected Band (if enabled) ---
         if (this.currentBandIndex >= 0 && this.currentBandIndex < this.numBands) {
@@ -928,7 +949,7 @@ class FiveBandDynamicEQ extends PluginBase {
                     const freq = freqPoints[i];
                     // Calculate bandpass response (at 0dB gain, slightly amplified for visualization)
                     const gain = this._calculateBandResponse(freq, band.scf, 0, band.scq, 'bp');
-                    const x = width * (Math.log10(freq) - Math.log10(minFreq)) / (Math.log10(maxFreq) - Math.log10(minFreq));
+                    const x = width * (Math.log10(freq) - logMinFreq) / logFreqSpan;
                     const y = height * (1 - (gain - minGain) / gainRange);
                     if (i === 0) { ctx.moveTo(x, y); } else { ctx.lineTo(x, y); }
                 }
@@ -945,7 +966,7 @@ class FiveBandDynamicEQ extends PluginBase {
                 for (let i = 0; i < freqPoints.length; i++) {
                     const freq = freqPoints[i];
                     const gain = this._calculateBandResponse(freq, band.f, staticGain, band.q, band.ft);
-                    const x = width * (Math.log10(freq) - Math.log10(minFreq)) / (Math.log10(maxFreq) - Math.log10(minFreq));
+                    const x = width * (Math.log10(freq) - logMinFreq) / logFreqSpan;
                     const y = height * (1 - (gain - minGain) / gainRange);
                     if (i === 0) { ctx.moveTo(x, y); } else { ctx.lineTo(x, y); }
                 }
@@ -954,50 +975,34 @@ class FiveBandDynamicEQ extends PluginBase {
         }
 
         // --- Draw the Dynamic Combined Response Curve (Bright Green) ---
-        // Always draw the dynamic curve, using latest gains or zero if unavailable.
-        // Get the latest smoothed gains from the audio processor, or use a zero array as fallback.
+        // Get the latest smoothed gains from the audio processor, or fall
+        // back to the cached zero array if not available yet.
         const currentGains = (this.latestSmoothedGains && this.latestSmoothedGains.length === this.numBands)
                         ? this.latestSmoothedGains
-                        : new Array(this.numBands).fill(0);
+                        : this._zeroGains;
 
-        // Calculate the combined frequency response by summing individual band responses (in dB).
-        // Note: Simply adding dB responses is common for visualization but not strictly accurate.
-        // A precise calculation would involve multiplying complex transfer functions before converting to dB.
-        const responsePoints = freqPoints.map(freq => {
-            let totalResponse = 0; // Initialize combined response for this frequency
+        // Compute and stroke the curve in a single pass; the per-point
+        // response is no longer materialized into a temporary array.
+        ctx.beginPath();
+        ctx.strokeStyle = '#00ff00'; // Bright green (like PEQ)
+        ctx.lineWidth = 3;
+        for (let i = 0; i < freqPoints.length; i++) {
+            const freq = freqPoints[i];
+            let totalResponse = 0;
             for (let bandIdx = 0; bandIdx < this.numBands; bandIdx++) {
                 const band = this.bs[bandIdx];
-                if (!band.en) continue; // Skip disabled bands
-
-                // Use the actual dynamic gain received from the processor (or the fallback 0).
-                const effectiveGain = currentGains[bandIdx];
-
-                // Add the dB response of this band to the total.
-                totalResponse += this._calculateBandResponse(freq, band.f, effectiveGain, band.q, band.ft);
+                if (!band.en) continue;
+                totalResponse += this._calculateBandResponse(freq, band.f, currentGains[bandIdx], band.q, band.ft);
             }
-            return totalResponse;
-        });
-
-        // Draw the calculated dynamic response curve.
-        ctx.beginPath();
-        ctx.strokeStyle = '#00ff00'; // Bright green color (like PEQ)
-        ctx.lineWidth = 3;       // Thicker line for the main response curve
-
-        for (let i = 0; i < freqPoints.length; i++) {
-            // Map frequency to x-coordinate (logarithmic)
-            const x = width * (Math.log10(freqPoints[i]) - Math.log10(minFreq)) / (Math.log10(maxFreq) - Math.log10(minFreq));
-
-            // Map calculated gain (dB) to y-coordinate (linear)
-            const y = height * (1 - (responsePoints[i] - minGain) / gainRange);
-
-            // Draw line segments
+            const x = width * (Math.log10(freq) - logMinFreq) / logFreqSpan;
+            const y = height * (1 - (totalResponse - minGain) / gainRange);
             if (i === 0) {
-                ctx.moveTo(x, y); // Start the path at the first point
+                ctx.moveTo(x, y);
             } else {
-                ctx.lineTo(x, y); // Draw line to subsequent points
+                ctx.lineTo(x, y);
             }
         }
-        ctx.stroke(); // Render the curve
+        ctx.stroke();
 
         // --- Draw Axis Labels ---
         ctx.fillStyle = '#fff'; // Use white for axis labels for clarity

--- a/plugins/eq/five_band_dynamic_eq.js
+++ b/plugins/eq/five_band_dynamic_eq.js
@@ -27,6 +27,10 @@ class FiveBandDynamicEQ extends PluginBase {
         // --- Canvas References ---
         this.canvas = null;
         this.ctx = null;
+        // Updated by IntersectionObserver once the canvas is mounted; the
+        // animation loop pauses while the canvas is scrolled out of view.
+        this.isVisible = true;
+        this.observer = null;
         // Remove fixed width/height, control via CSS
         // this.canvasWidth = 400;
         // this.canvasHeight = 200;
@@ -616,6 +620,19 @@ class FiveBandDynamicEQ extends PluginBase {
         graphContainer.appendChild(this.canvas);
         container.appendChild(graphContainer);
 
+        // Pause the redraw loop while the canvas is off-screen.
+        this.observer = new IntersectionObserver(entries => {
+            for (const entry of entries) {
+                this.isVisible = entry.isIntersecting;
+                if (this.isVisible) {
+                    this.startAnimation();
+                } else {
+                    this.stopAnimation();
+                }
+            }
+        });
+        this.observer.observe(this.canvas);
+
         // Initial setup
         this.startAnimation();
 
@@ -1147,8 +1164,13 @@ class FiveBandDynamicEQ extends PluginBase {
     startAnimation() {
         if (this.animationFrameId) return; // Already running
         if (!this.enabled || !this._sectionEnabled) return; // Skip if disabled or section is off.
+        if (this.isVisible === false) return;                // Skip if off-screen.
         const animate = () => {
-            this._drawGraph(); // Redraw graph with potentially updated (dynamic) data
+            if (this.isVisible === false) {
+                this.stopAnimation();
+                return;
+            }
+            this._drawGraph();
             this.animationFrameId = requestAnimationFrame(animate);
         };
         this.animationFrameId = requestAnimationFrame(animate);
@@ -1168,6 +1190,10 @@ class FiveBandDynamicEQ extends PluginBase {
         if (this.resizeObserver) {
              this.resizeObserver.disconnect(); // Disconnect observer
              this.resizeObserver = null;
+        }
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
         }
         this.canvas = null;
         this.ctx = null;

--- a/plugins/eq/five_band_dynamic_eq.js
+++ b/plugins/eq/five_band_dynamic_eq.js
@@ -1141,6 +1141,7 @@ class FiveBandDynamicEQ extends PluginBase {
     // --- Animation Loop for Dynamic Graph ---
     startAnimation() {
         if (this.animationFrameId) return; // Already running
+        if (!this.enabled) return; // Don't start the redraw loop while disabled.
         const animate = () => {
             this._drawGraph(); // Redraw graph with potentially updated (dynamic) data
             this.animationFrameId = requestAnimationFrame(animate);

--- a/plugins/plugin-base.js
+++ b/plugins/plugin-base.js
@@ -502,10 +502,26 @@ class PluginBase {
     }
 
     // Enable or disable the plugin.
+    //
+    // When a plugin exposes startAnimation()/stopAnimation() (used by
+    // analyzer-style plugins to drive a per-frame canvas redraw), pause that
+    // loop while the plugin is disabled. Previously the redraw loop kept
+    // running at the display refresh rate even when the user toggled the
+    // plugin off via the ON button, which wastes main-thread CPU and is
+    // especially noticeable on low-power hardware. The animation is resumed
+    // when the plugin is re-enabled.
     setEnabled(enabled) {
         if (this.enabled !== enabled) {
             this.enabled = enabled;
             this.updateParameters();
+            if (typeof this.startAnimation === 'function' &&
+                typeof this.stopAnimation === 'function') {
+                if (enabled) {
+                    this.startAnimation();
+                } else {
+                    this.stopAnimation();
+                }
+            }
         }
     }
 

--- a/plugins/plugin-base.js
+++ b/plugins/plugin-base.js
@@ -8,6 +8,11 @@ class PluginBase {
         this.name = name;
         this.description = description;
         this.enabled = true;
+        // Whether the section the plugin belongs to is enabled. The pipeline
+        // updates this when the user toggles a Section's ON button; used
+        // together with `enabled` to decide whether the plugin's redraw loop
+        // (startAnimation/stopAnimation) should run.
+        this._sectionEnabled = true;
         this.id = null; // Will be set by createPlugin
         this.errorState = null; // Holds error state
         this.inputBus = null; // Input bus (null = default Main bus, index 0)
@@ -505,23 +510,42 @@ class PluginBase {
     //
     // When a plugin exposes startAnimation()/stopAnimation() (used by
     // analyzer-style plugins to drive a per-frame canvas redraw), pause that
-    // loop while the plugin is disabled. Previously the redraw loop kept
-    // running at the display refresh rate even when the user toggled the
-    // plugin off via the ON button, which wastes main-thread CPU and is
-    // especially noticeable on low-power hardware. The animation is resumed
-    // when the plugin is re-enabled.
+    // loop while the plugin is effectively disabled (either by its own ON
+    // button or by its enclosing Section being OFF). Previously the redraw
+    // loop kept running at the display refresh rate even when disabled,
+    // which wasted main-thread CPU on low-power hardware.
     setEnabled(enabled) {
         if (this.enabled !== enabled) {
             this.enabled = enabled;
             this.updateParameters();
-            if (typeof this.startAnimation === 'function' &&
-                typeof this.stopAnimation === 'function') {
-                if (enabled) {
-                    this.startAnimation();
-                } else {
-                    this.stopAnimation();
-                }
-            }
+            this._refreshAnimationState();
+        }
+    }
+
+    // Called from the pipeline UI when the enclosing Section is toggled.
+    // Stops the redraw loop while the section is OFF and starts it again
+    // when the section comes back ON (provided the plugin itself is also
+    // enabled).
+    _setSectionEnabled(sectionEnabled) {
+        sectionEnabled = sectionEnabled !== false;
+        if (this._sectionEnabled !== sectionEnabled) {
+            this._sectionEnabled = sectionEnabled;
+            this._refreshAnimationState();
+        }
+    }
+
+    // Start or stop the redraw loop to match the current effective-enabled
+    // state. Plugins that do not expose startAnimation/stopAnimation are
+    // unaffected.
+    _refreshAnimationState() {
+        if (typeof this.startAnimation !== 'function' ||
+            typeof this.stopAnimation !== 'function') {
+            return;
+        }
+        if (this.enabled && this._sectionEnabled) {
+            this.startAnimation();
+        } else {
+            this.stopAnimation();
         }
     }
 


### PR DESCRIPTION
> Reference implementation for #32. Discussion / direction lives in the
> issue; per-commit review here. Each commit is independently
> reviewable / revertible.

## Background

On underpowered hardware — Raspberry Pi 5 was the trigger — users hear
frequent audio dropouts ("crackles") while interacting with the EffeTune
UI, especially when scrolling the pipeline area. A DevTools Performance
profile on a Pi 5 attributed almost all of the additional cost to the
main thread, where several independently small inefficiencies added up
to enough load to starve the audio render thread of its 2.6 ms budget.

The actual DSP is fine; the cost is in the GUI.

This PR collects a series of small, focused changes to the GUI that
together eliminate that pressure. On capable hardware the changes are
functionally invisible — the UI behaves identically and the cost is
negligible. On a Pi 5 they make the difference between audible glitches
during scrolling and clean playback.

See #32 for the full investigation.

## Changes (commit-by-commit)

1. **Pause analyzer animation loops while the plugin is disabled** —
   `PluginBase.setEnabled()` now drives `startAnimation()` /
   `stopAnimation()` so any plugin with a per-frame redraw loop pauses
   automatically when toggled OFF.

2. **Route plugin enable/disable through setEnabled() consistently** —
   the pipeline's ON button and the preset/URL deserializer now call
   `plugin.setEnabled()` instead of writing `plugin.enabled` directly.

3. **Pause analyzer animations inside a section when the section is
   OFF** — toggling a Section walks the inner plugins and notifies
   each one, mirroring the worklet's section-active gating on the
   main thread.

4. **Guard every `startAnimation()` against running while disabled** —
   prevents the IntersectionObserver from quietly restarting a redraw
   loop after a scroll round-trip on a plugin that is OFF.

5. **Eliminate per-frame allocations in 5-Band Dynamic EQ graph redraw**
   — the static frequency axis is precomputed once; the dynamic
   response is computed and stroked in a single pass. Removes ~1,000
   short-lived `Float` entries per frame.

6. **Use CSS containment on each pipeline plugin card**
   (`contain: layout style paint`) — lets the browser skip hit-testing
   and re-painting off-screen plugin cards while scrolling.

7. **Honor enclosing Section's enabled state when (re)starting
   animations** — adds `plugin._sectionEnabled` so that subsequent
   `startAnimation()` calls (e.g. the IntersectionObserver firing on
   scroll-in) keep respecting the section's OFF state.

8. **Add IntersectionObserver to 5-Band Dynamic EQ** — the plugin
   previously redrew its dynamic graph at 60 Hz even when scrolled
   completely off-screen.

9. **Replace per-frame `getBoundingClientRect` with IntersectionObserver**
   in Compressor / Expander / Gate / Multiband Compressor / Multiband
   Expander — eliminating five forced synchronous-layout calls per
   frame.

## Effect

On a Raspberry Pi 5 with a real-world pipeline:

- Toggling a plugin or a Section OFF now actually frees main-thread
  CPU (the redraw loop stops, instead of running invisibly).
- Main-thread CPU consumed during scrolling drops substantially.
  Plugin cards outside the viewport no longer participate in
  per-frame paint/hit-test work, and several per-frame
  `getBoundingClientRect()` calls are gone.
- Audible glitches during UI interaction (clicks during scroll, ON/OFF
  toggles, parameter sweeps) are largely eliminated on this hardware.

On capable hardware the same changes have no perceptible effect on
behavior or performance.

## Compatibility

- No visual changes.
- No public API changes. `setEnabled()` and
  `startAnimation()`/`stopAnimation()` were already the conventions
  analyzer plugins used; this PR simply makes them the canonical
  enable/disable path.
- Plugins that don't expose `startAnimation`/`stopAnimation` are
  unaffected.
- No new dependencies. `IntersectionObserver` and CSS `contain` are
  baseline-supported by the Chromium versions EffeTune ships with.

## Risk

Localized. Each change is small, scoped to one of:
- `PluginBase` (one new flag, one new method, one routing fix)
- the pipeline's ON-button click handler
- `serialization-utils.js` (one routing fix)
- per-analyzer `startAnimation()` (additional guard)
- per-analyzer createUI (IntersectionObserver wiring)
- one CSS rule on `.pipeline-item`

No part of the audio path (worklet, signal flow, sample rate handling)
is touched.