### PR TITLE
Reduce idle power in sleep mode: pause analyzer redraws and release the output device

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -752,9 +752,16 @@ class App {
 
         // Auto-resume audio context when page gains focus
         document.addEventListener('visibilitychange', () => {
-            if (!document.hidden && this.audioManager.audioContext &&
-                this.audioManager.audioContext.state === 'suspended') {
-                this.audioManager.audioContext.resume();
+            if (document.hidden) return;
+            const am = this.audioManager;
+            // If suspended for sleep-mode power saving, go through the wake
+            // path so the worklet and watcher state are torn down properly.
+            if (am._sleepSuspended) {
+                am.wakeFromSleep();
+                return;
+            }
+            if (am.audioContext && am.audioContext.state === 'suspended') {
+                am.audioContext.resume();
             }
         });
 

--- a/js/audio-manager.js
+++ b/js/audio-manager.js
@@ -4,6 +4,7 @@ import { PipelineProcessor } from './audio/pipeline-processor.js';
 import { OfflineProcessor } from './audio/offline-processor.js';
 import { AudioEncoder } from './audio/audio-encoder.js';
 import { EventManager } from './audio/event-manager.js';
+import { InputActivityWatcher } from './audio/input-activity-watcher.js';
 import { getSerializablePluginStateShort, applySerializedState } from './utils/serialization-utils.js';
 
 /**
@@ -48,7 +49,13 @@ export class AudioManager {
         this.isCancelled = false;
         this._skipAudioInitDuringSampleRateChange = false;
         this.isFirstLaunch = false;
-        
+
+        // Sleep-mode output power saving (see _enterSleepPowerSave). True
+        // while the AudioContext is intentionally suspended so the output
+        // device (and DAC/Amp) can power down during idle sleep.
+        this._sleepSuspended = false;
+        this._inputActivityWatcher = null;
+
         // Set global reference
         window.audioManager = this;
     }
@@ -300,6 +307,17 @@ export class AudioManager {
                             isSleepMode: data.isSleepMode,
                             sampleRate: this.audioContext.sampleRate
                         });
+
+                        // Release the output device while idle so the DAC/Amp
+                        // can power down (non-macOS only; see methods below).
+                        if (data.isSleepMode) {
+                            this._enterSleepPowerSave();
+                        } else if (this._sleepSuspended) {
+                            // A wake reported by the worklet (only possible
+                            // after we already resumed it) - make sure our
+                            // power-save state is torn down.
+                            this.wakeFromSleep();
+                        }
                     }
                 };
             }
@@ -309,7 +327,120 @@ export class AudioManager {
             return `Audio Error: ${error.message}`;
         }
     }
-    
+
+    /**
+     * Whether sleep-mode output power saving may run.
+     *
+     * Intentionally a no-op on macOS: there, EffeTune carries a
+     * carefully-tuned audio-device recovery path for HDMI hotplug /
+     * CoreAudio behavior which, of necessity, treats AudioContext
+     * suspend/close transitions as failure signals. A deliberate suspend
+     * would collide with that hard-won machinery for little gain, since
+     * the power-saving target is a low-power always-on Linux host (Pi +
+     * DAC). So we simply don't engage it on macOS.
+     * @returns {boolean}
+     */
+    _sleepPowerSaveSupported() {
+        if (window.electronAPI?.platform === 'darwin') return false;
+        return !!this.audioContext;
+    }
+
+    /**
+     * Called when the worklet enters sleep mode. Suspends the AudioContext
+     * so the OS output device - and the downstream DAC/Amp - can power
+     * down. Auto-wake on returning input is preserved by watching the
+     * input track with a device-free MediaStreamTrackProcessor (the
+     * suspended worklet can no longer do it). If that watcher can't be
+     * established, we keep the context running rather than lose wake-on-input.
+     */
+    async _enterSleepPowerSave() {
+        if (this._sleepSuspended) return;
+        if (!this._sleepPowerSaveSupported()) return;
+
+        const track = this.stream?.getAudioTracks?.()[0] ?? null;
+        if (!track || !InputActivityWatcher.isSupported()) {
+            // No device-free way to detect input returning (e.g. file
+            // playback, or API unavailable) - leave the context running so
+            // the worklet keeps handling wake-on-input (status quo).
+            return;
+        }
+
+        this._sleepSuspended = true;
+        // Mark the suspend as deliberate so the context manager's
+        // onstatechange handler does not immediately auto-resume it.
+        this.contextManager.setIntentionalSuspend(true);
+        try {
+            await this.audioContext.suspend();
+        } catch (e) {
+            console.warn('[AudioManager] sleep-mode suspend failed:', e);
+        }
+
+        // We may have been woken (user activity) during the await above.
+        if (!this._sleepSuspended) {
+            this.contextManager.setIntentionalSuspend(false);
+            await this.audioContext.resume().catch(() => {});
+            return;
+        }
+
+        // In HTMLMediaElement output mode the <audio> element holds its own
+        // sink open, so pause it too. Context-sink / direct modes route
+        // through audioContext.destination, which suspend() already released.
+        const io = this.ioManager;
+        if (io?.audioElement && !io.audioContextSinkMode && !io.directOutputMode) {
+            try { io.audioElement.pause(); } catch { /* ignore */ }
+        }
+
+        if (!this._inputActivityWatcher) {
+            // Mirror the worklet's silence test: AC peak-to-peak above
+            // 2x the -84 dB amplitude threshold counts as signal.
+            const acThreshold = 2 * Math.pow(10, -84 / 20);
+            this._inputActivityWatcher = new InputActivityWatcher(acThreshold);
+        }
+        const watching = this._inputActivityWatcher.start(track, () => this.wakeFromSleep());
+        if (!watching) {
+            // Lost our only wake-on-input mechanism - resume rather than
+            // risk staying asleep with no audio path.
+            this.wakeFromSleep();
+            return;
+        }
+        const mode = io?.directOutputMode ? 'direct'
+            : io?.audioContextSinkMode ? 'audioContextSink'
+            : io?.audioElement ? 'mediaElement' : 'default';
+        console.log(`[AudioManager] sleep power-save active (output mode: ${mode}); output device released`);
+    }
+
+    /**
+     * Resume from sleep-mode power saving: re-open the output device and
+     * nudge the worklet awake. Safe to call repeatedly. Driven by the input
+     * watcher, by user activity, and by window-visibility changes.
+     */
+    async wakeFromSleep() {
+        if (!this._sleepSuspended) return;
+        this._sleepSuspended = false;
+
+        if (this._inputActivityWatcher) this._inputActivityWatcher.stop();
+        this.contextManager.setIntentionalSuspend(false);
+
+        try {
+            await this.audioContext.resume();
+        } catch (e) {
+            console.warn('[AudioManager] sleep-mode resume failed:', e);
+        }
+
+        const io = this.ioManager;
+        if (io?.audioElement && !io.audioContextSinkMode && !io.directOutputMode) {
+            try { await io.audioElement.play(); } catch { /* ignore */ }
+        }
+
+        // Nudge the worklet: clears its cached sleep state, resets the
+        // inactivity timers, and makes it emit sleepModeChanged:false so the
+        // UI and analyzer redraw loops resume normally.
+        if (this.workletNode) {
+            this.workletNode.port.postMessage({ type: 'userActivity' });
+        }
+        console.log('[AudioManager] sleep power-save: woke; output device resumed');
+    }
+
     /**
      * Update properties exposed for backward compatibility
      */
@@ -424,6 +555,16 @@ export class AudioManager {
      * then rebuilds context → worklet → pipeline.
      */
     async _doReset(audioPreferences = null) {
+        // Tear down any sleep-mode power-save state before rebuilding the
+        // audio graph: the watcher holds a clone of the old input track, and
+        // a lingering intentional-suspend flag would otherwise suppress
+        // legitimate auto-resume on the freshly created context.
+        if (this._sleepSuspended) {
+            this._sleepSuspended = false;
+            if (this._inputActivityWatcher) this._inputActivityWatcher.stop();
+            this.contextManager.setIntentionalSuspend(false);
+        }
+
         // Clean up audio I/O
         this.ioManager.cleanupAudio();
 

--- a/js/audio-manager.js
+++ b/js/audio-manager.js
@@ -284,6 +284,17 @@ export class AudioManager {
                 this.workletNode.port.onmessage = (event) => {
                     const data = event.data;
                     if (data.type === 'sleepModeChanged') {
+                        // Propagate sleep state to every plugin so that
+                        // analyzer-style plugins can pause their main-thread
+                        // redraw loop while the audio path is idle. Plugins
+                        // that don't expose _setSleepMode are unaffected.
+                        if (this.pipeline) {
+                            for (const plugin of this.pipeline) {
+                                if (typeof plugin._setSleepMode === 'function') {
+                                    plugin._setSleepMode(data.isSleepMode);
+                                }
+                            }
+                        }
                         // Dispatch sleep mode changed event
                         this.dispatchEvent('sleepModeChanged', {
                             isSleepMode: data.isSleepMode,

--- a/js/audio/audio-context-manager.js
+++ b/js/audio/audio-context-manager.js
@@ -12,11 +12,24 @@ export class AudioContextManager {
         this.silenceGain = null;
         this.isFirstLaunch = false;
         this._skipAudioInitDuringSampleRateChange = false;
-        
+        // True while the context is suspended on purpose for sleep-mode
+        // power saving, so onstatechange knows not to auto-resume it.
+        this._intentionalSuspend = false;
+
         // Initialize global variable if not already set
         if (typeof window.originalConnectMethod === 'undefined') {
             window.originalConnectMethod = null;
         }
+    }
+
+    /**
+     * Mark (or clear) an intentional suspend for sleep-mode power saving.
+     * While set, the onstatechange handler will not auto-resume a
+     * 'suspended' context, since that suspend was deliberate.
+     * @param {boolean} value
+     */
+    setIntentionalSuspend(value) {
+        this._intentionalSuspend = !!value;
     }
     
     /**
@@ -91,6 +104,12 @@ export class AudioContextManager {
                 this.audioContext.onstatechange = () => {
                     const state = this.audioContext?.state;
                     if (state === 'suspended') {
+                        // A deliberate suspend for sleep-mode power saving must
+                        // not be auto-resumed; AudioManager.wakeFromSleep owns
+                        // the resume in that case.
+                        if (this._intentionalSuspend) {
+                            return;
+                        }
                         this.audioContext.resume().catch(err =>
                             console.warn('[AudioContext] resume after suspended failed:', err)
                         );

--- a/js/audio/event-manager.js
+++ b/js/audio/event-manager.js
@@ -40,6 +40,13 @@ export class EventManager {
      * Handle user activity events
      */
     handleUserActivity() {
+        // If the context is suspended for sleep-mode power saving, the
+        // worklet is frozen and can't act on the message, so wake from the
+        // main thread (wakeFromSleep re-posts userActivity after resuming).
+        if (this.audioManager._sleepSuspended) {
+            this.audioManager.wakeFromSleep();
+            return;
+        }
         // Notify audio processor about user activity
         if (this.audioManager.workletNode) {
             this.audioManager.workletNode.port.postMessage({

--- a/js/audio/input-activity-watcher.js
+++ b/js/audio/input-activity-watcher.js
@@ -1,0 +1,136 @@
+/**
+ * InputActivityWatcher - detects audio activity on a MediaStreamTrack
+ * WITHOUT opening any output device.
+ *
+ * It is used while the main AudioContext is suspended for sleep-mode power
+ * saving (so the output device, and the downstream DAC/Amp, can power down).
+ * A suspended AudioContext freezes the worklet, which is what normally
+ * detects the input signal returning, so we need a wake-on-input detector
+ * that does not depend on the context running. `MediaStreamTrackProcessor`
+ * reads raw AudioData frames straight off a track with no AudioContext and
+ * therefore opens no sink.
+ *
+ * Only the AC component matters - a constant DC offset is inaudible - so we
+ * track min/max per frame and treat a block as "signal" when
+ * (max - min) > acThreshold, mirroring the silence test in
+ * plugins/audio-processor.js.
+ */
+export class InputActivityWatcher {
+    /** @returns {boolean} whether the required API is available */
+    static isSupported() {
+        return typeof window.MediaStreamTrackProcessor !== 'undefined';
+    }
+
+    /**
+     * @param {number} acThreshold - peak-to-peak amplitude above which a
+     *   block counts as signal (linear, not dB).
+     */
+    constructor(acThreshold) {
+        this._acThreshold = acThreshold;
+        this._reader = null;
+        this._track = null;
+        this._stopped = true;
+        this._warnedCopyFailure = false;
+    }
+
+    /**
+     * Begin watching `sourceTrack`. `onSignal` fires once, the first time
+     * audio activity is seen; the watcher then stops itself.
+     * @returns {boolean} false if it could not start (caller should fall back)
+     */
+    start(sourceTrack, onSignal) {
+        if (!InputActivityWatcher.isSupported() || !sourceTrack) return false;
+        try {
+            // Clone so MediaStreamTrackProcessor doesn't lock/consume the
+            // track that the (suspended) MediaStreamAudioSourceNode still
+            // references; the clone shares the same underlying source.
+            this._track = sourceTrack.clone();
+            const processor = new window.MediaStreamTrackProcessor({ track: this._track });
+            this._reader = processor.readable.getReader();
+        } catch (e) {
+            console.warn('[InputActivityWatcher] failed to start:', e);
+            this.stop();
+            return false;
+        }
+        this._stopped = false;
+        this._readLoop(onSignal);
+        return true;
+    }
+
+    async _readLoop(onSignal) {
+        const reader = this._reader;
+        while (!this._stopped && reader) {
+            let result;
+            try {
+                result = await reader.read();
+            } catch {
+                break;
+            }
+            if (this._stopped) break;
+            const frame = result.value;
+            if (result.done) break;
+            if (!frame) continue;
+            let active = false;
+            try {
+                active = this._frameHasSignal(frame);
+            } finally {
+                frame.close(); // AudioData must be closed to avoid leaks
+            }
+            if (active) {
+                this.stop();
+                try {
+                    onSignal();
+                } catch (e) {
+                    console.warn('[InputActivityWatcher] onSignal threw:', e);
+                }
+                return;
+            }
+        }
+    }
+
+    /** @param {AudioData} frame */
+    _frameHasSignal(frame) {
+        const samples = frame.numberOfFrames;
+        if (!samples) return false;
+        const buf = new Float32Array(samples);
+        try {
+            // Read the first channel as planar float32.
+            frame.copyTo(buf, { planeIndex: 0, format: 'f32-planar' });
+        } catch (e) {
+            if (!this._warnedCopyFailure) {
+                this._warnedCopyFailure = true;
+                console.warn('[InputActivityWatcher] AudioData.copyTo(f32-planar) failed:', e);
+            }
+            return false;
+        }
+        const threshold = this._acThreshold;
+        let min = buf[0];
+        let max = buf[0];
+        for (let i = 1; i < samples; i++) {
+            const s = buf[i];
+            if (s < min) min = s;
+            else if (s > max) max = s;
+            if (max - min > threshold) return true; // early-out
+        }
+        return max - min > threshold;
+    }
+
+    stop() {
+        this._stopped = true;
+        if (this._reader) {
+            try {
+                this._reader.cancel();
+            } catch { /* already closed */ }
+            try {
+                this._reader.releaseLock();
+            } catch { /* not held */ }
+            this._reader = null;
+        }
+        if (this._track) {
+            try {
+                this._track.stop();
+            } catch { /* already stopped */ }
+            this._track = null;
+        }
+    }
+}

--- a/plugins/analyzer/level_meter.js
+++ b/plugins/analyzer/level_meter.js
@@ -281,7 +281,7 @@ class LevelMeterPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled || !this._sectionEnabled) return;
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/analyzer/oscilloscope.js
+++ b/plugins/analyzer/oscilloscope.js
@@ -550,7 +550,7 @@ class OscilloscopePlugin extends PluginBase {
 
     startAnimation() {
         if (this.animationFrameId) return;
-        if (!this.enabled || !this._sectionEnabled) return; // Skip if disabled or section is off.
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return; // Skip if disabled or section is off.
 
         const animate = () => {
             if (!this.isVisible) {

--- a/plugins/analyzer/spectrogram.js
+++ b/plugins/analyzer/spectrogram.js
@@ -249,7 +249,7 @@ class SpectrogramPlugin extends PluginBase {
 
     process(message) {
         if (!message?.measurements?.buffer) return;
-        if (!this.enabled || !this._sectionEnabled) return;
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
         if (!this.spectrogramBuffer) return; // Check if spectrogramBuffer exists
 
         const fftSize = 1 << this.pt;
@@ -424,7 +424,7 @@ class SpectrogramPlugin extends PluginBase {
     }
 
     handleIntersect(entries) { /* ... (same as original) ... */ entries.forEach(entry => {this.isVisible = entry.isIntersecting; if (this.isVisible) {this.startAnimation();} else {this.stopAnimation();}}); }
-    startAnimation() { /* ... (same as original) ... */ if (this.animationFrameId) return; if (!this.enabled || !this._sectionEnabled) return; const animate = () => {if (!this.isVisible) {this.stopAnimation(); return;} this.drawGraph(); this.animationFrameId = requestAnimationFrame(animate);}; animate(); }
+    startAnimation() { /* ... (same as original) ... */ if (this.animationFrameId) return; if (!this.enabled || !this._sectionEnabled || this._sleepMode) return; const animate = () => {if (!this.isVisible) {this.stopAnimation(); return;} this.drawGraph(); this.animationFrameId = requestAnimationFrame(animate);}; animate(); }
     stopAnimation() { /* ... (same as original) ... */ if (this.animationFrameId) {cancelAnimationFrame(this.animationFrameId); this.animationFrameId = null;} }
     cleanup() { /* ... (mostly same, ensure listeners are correctly removed if stored differently) ... */
         this.stopAnimation();

--- a/plugins/analyzer/spectrum_analyzer.js
+++ b/plugins/analyzer/spectrum_analyzer.js
@@ -363,7 +363,7 @@ class SpectrumAnalyzerPlugin extends PluginBase {
 
     startAnimation() {
         if (this.animationFrameId) return;
-        if (!this.enabled || !this._sectionEnabled) return; // Skip if disabled or section is off.
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return; // Skip if disabled or section is off.
         const animate = () => {
             if (!this.isVisible) {
                 this.stopAnimation();

--- a/plugins/analyzer/stereo_meter.js
+++ b/plugins/analyzer/stereo_meter.js
@@ -256,7 +256,7 @@ class StereoMeterPlugin extends PluginBase {
   }
 
   startAnimation() {
-      if (!this.enabled || !this._sectionEnabled) return;
+      if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
     if (this.animationFrameId) return;
 
     const animate = () => {

--- a/plugins/dynamics/auto_leveler.js
+++ b/plugins/dynamics/auto_leveler.js
@@ -381,7 +381,7 @@ class AutoLevelerPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled || !this._sectionEnabled) return;
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/dynamics/compressor.js
+++ b/plugins/dynamics/compressor.js
@@ -604,7 +604,7 @@ class CompressorPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled || !this._sectionEnabled) return;
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;

--- a/plugins/dynamics/expander.js
+++ b/plugins/dynamics/expander.js
@@ -606,7 +606,7 @@ class ExpanderPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled || !this._sectionEnabled) return;
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;

--- a/plugins/dynamics/gate.js
+++ b/plugins/dynamics/gate.js
@@ -735,7 +735,7 @@ class GatePlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled || !this._sectionEnabled) return;
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
         if (this.animationFrameId) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = null;

--- a/plugins/dynamics/multiband_compressor.js
+++ b/plugins/dynamics/multiband_compressor.js
@@ -1221,7 +1221,7 @@ class MultibandCompressorPlugin extends PluginBase {
   }
 
   startAnimation() {
-      if (!this.enabled || !this._sectionEnabled) return;
+      if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
     if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId);
     
     let lastGraphState = null;

--- a/plugins/dynamics/multiband_expander.js
+++ b/plugins/dynamics/multiband_expander.js
@@ -1100,7 +1100,7 @@ class MultibandExpanderPlugin extends PluginBase {
   }
 
   startAnimation() {
-      if (!this.enabled || !this._sectionEnabled) return;
+      if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
     if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId);
 
     let lastGraphState = null;

--- a/plugins/dynamics/multiband_transient.js
+++ b/plugins/dynamics/multiband_transient.js
@@ -560,7 +560,7 @@ class MultibandTransientPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled || !this._sectionEnabled) return;
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/dynamics/power_amp_sag.js
+++ b/plugins/dynamics/power_amp_sag.js
@@ -291,7 +291,7 @@ class PowerAmpSagPlugin extends PluginBase {
     }
     
     startAnimation() {
-        if (!this.enabled || !this._sectionEnabled) return;
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
         if (this.animationFrameId) return;
         
         const animate = () => {

--- a/plugins/dynamics/transient_shaper.js
+++ b/plugins/dynamics/transient_shaper.js
@@ -160,7 +160,7 @@ class TransientShaperPlugin extends PluginBase {
     }
 
     startAnimation() {
-        if (!this.enabled || !this._sectionEnabled) return;
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return;
         if (this.animationFrameId) return;
 
         const animate = () => {

--- a/plugins/eq/five_band_dynamic_eq.js
+++ b/plugins/eq/five_band_dynamic_eq.js
@@ -1163,7 +1163,7 @@ class FiveBandDynamicEQ extends PluginBase {
     // --- Animation Loop for Dynamic Graph ---
     startAnimation() {
         if (this.animationFrameId) return; // Already running
-        if (!this.enabled || !this._sectionEnabled) return; // Skip if disabled or section is off.
+        if (!this.enabled || !this._sectionEnabled || this._sleepMode) return; // Skip if disabled or section is off.
         if (this.isVisible === false) return;                // Skip if off-screen.
         const animate = () => {
             if (this.isVisible === false) {

--- a/plugins/plugin-base.js
+++ b/plugins/plugin-base.js
@@ -13,6 +13,15 @@ class PluginBase {
         // together with `enabled` to decide whether the plugin's redraw loop
         // (startAnimation/stopAnimation) should run.
         this._sectionEnabled = true;
+        // Whether the worklet is in sleep mode (no input/output signal and
+        // no user activity for the configured duration). The AudioManager
+        // propagates the sleep transitions here so analyzers can also pause
+        // their main-thread redraw loops while the audio path is idle.
+        // Any user interaction wakes the worklet up immediately via the
+        // existing 'userActivity' channel, so editing while in sleep is
+        // safe -- the wake-up reverts this flag before the user sees a
+        // stale UI.
+        this._sleepMode = false;
         this.id = null; // Will be set by createPlugin
         this.errorState = null; // Holds error state
         this.inputBus = null; // Input bus (null = default Main bus, index 0)
@@ -534,6 +543,19 @@ class PluginBase {
         }
     }
 
+    // Called from the AudioManager when the worklet enters or leaves sleep
+    // mode. While the audio path is idle, there's nothing meaningful for the
+    // analyzer to redraw, so we pause the main-thread loop too. Any user
+    // interaction wakes the worklet via 'userActivity', which causes this to
+    // be called again with sleepMode=false.
+    _setSleepMode(sleepMode) {
+        sleepMode = !!sleepMode;
+        if (this._sleepMode !== sleepMode) {
+            this._sleepMode = sleepMode;
+            this._refreshAnimationState();
+        }
+    }
+
     // Start or stop the redraw loop to match the current effective-enabled
     // state. Plugins that do not expose startAnimation/stopAnimation are
     // unaffected.
@@ -542,7 +564,7 @@ class PluginBase {
             typeof this.stopAnimation !== 'function') {
             return;
         }
-        if (this.enabled && this._sectionEnabled) {
+        if (this.enabled && this._sectionEnabled && !this._sleepMode) {
             this.startAnimation();
         } else {
             this.stopAnimation();


### PR DESCRIPTION
> Reference implementation for #36. The symptom, diagnosis and reasoning live in the issue; this PR is the patch.

Two independent idle-power drains while the worklet is asleep, kept as two commits so each is reviewable / revertible on its own:

1. **Pause analyzer redraws** - propagate the worklet's `sleepModeChanged` to plugins via `PluginBase._setSleepMode()`, extending the existing `startAnimation()` guard (from #33) with the sleep state. ~37% -> ~2% main-thread CPU on a Pi 5.

2. **Release the output device** - `suspend()` the `AudioContext` on sleep so the OS output stream (and the downstream DAC/Amp) is released. Auto-wake is preserved by a device-free `MediaStreamTrackProcessor` watcher over a clone of the input track (new `js/audio/input-activity-watcher.js`); user activity and window visibility also wake via `AudioManager.wakeFromSleep()`. The context manager's `onstatechange` auto-resume is gated so the deliberate suspend isn't undone. **No-op on macOS** (stays clear of the HDMI/CoreAudio recovery path there); also falls back to the status quo when `MediaStreamTrackProcessor` is unavailable or the input isn't a live MediaStream.

Verified on a Raspberry Pi 5 (input = virtual mic, output = USB DAC): the DAC node goes from `RUNNING` to suspended in pipewire while asleep and resumes on returning audio or UI activity; idle main-thread CPU drops as above.

Happy to split this into two PRs if you'd prefer to take them separately.