### PR TITLE
Fix unresponsive window after taskbar-restore from minimize-to-tray

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -796,9 +796,14 @@ function createWindow() {
   mainWindow.on('maximize', () => windowState.saveWindowState());
   mainWindow.on('unmaximize', () => windowState.saveWindowState());
   
-  mainWindow.on('minimize', (e) => {
+  mainWindow.on('minimize', () => {
     if (constants.getAppConfig().minimizeToTray) {
-      e.preventDefault();
+      // 'minimize' is not a preventable event — the window is already
+      // minimized when it fires, so hide() leaves the window in a combined
+      // minimized+hidden state.  restore() from that state re-shows the
+      // native window but leaves Chromium's internal visibility state hidden,
+      // making the window input-dead (the 'restore' handler below resyncs it
+      // with show()).
       mainWindow.hide();
       createTray();
       // Request tray menu update from renderer process
@@ -809,6 +814,11 @@ function createWindow() {
   });
 
   mainWindow.on('restore', () => {
+    // If the window was restored out of the minimized+hidden tray state,
+    // the native window is visible again but Chromium's internal visibility
+    // state is still hidden, leaving the window unable to receive input.
+    // show() resyncs it, and is harmless when the window is already visible.
+    mainWindow.show();
     if (tray) {
       tray.destroy();
       tray = null;
@@ -1429,8 +1439,20 @@ if (!gotTheLock) {
     // Focus the main window if it exists
     const mainWindow = constants.getMainWindow();
     if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.focus();
+      // Skip presenting the window while the startup splash still owns the
+      // screen — the deferred show in the splash flow will present it.
+      if (!pendingMainWindowShow) {
+        // restore() first, so a minimized window returns to its pre-minimize
+        // state (a bare show() would lose the maximized state — isMaximized()
+        // is false while minimized).  Then show(): restore() alone on a
+        // window hidden by the minimize-to-tray flow re-shows the native
+        // window but leaves Chromium's internal visibility state hidden,
+        // making the window input-dead.  show() also covers the hidden-but-
+        // not-minimized tray state, where focus() alone did nothing visible.
+        if (mainWindow.isMinimized()) mainWindow.restore();
+        mainWindow.show();
+        mainWindow.focus();
+      }
       
       // If there's a preset file, send it to the renderer
       const commandLinePresetFile = constants.getCommandLinePresetFile();


### PR DESCRIPTION
Fixes #42

When "Minimize to tray" is enabled, minimizing leaves the window in a combined minimized+hidden state: the `minimize` event is not preventable (it fires after the window is already minimized), so `e.preventDefault()` is a no-op and `hide()` runs on an already-minimized window.

Restoring out of that state via the `second-instance` handler re-shows the HWND, but Chromium still treats the window as hidden: it keeps rendering (backgroundThrottling is disabled) but never receives input. `show()` resyncs the widget state.

Changes to electron/main.js:
- `minimize` handler: drop the ineffective `e.preventDefault()`, document the minimized+hidden state
- `restore` handler: call `show()` to resync Chromium's visibility state (harmless when already visible)
- `second-instance` handler: `restore()` first (a bare `show()` on a minimized window loses the maximized state — `isMaximized()` is false while minimized), then `show()`/`focus()`; skipped while the startup splash owns the screen (`pendingMainWindowShow`). This also covers the hidden-but-not-minimized tray state, where `focus()` alone did nothing visible.

Tested on Windows 11 against the repro (open from tray → minimize → click the pinned taskbar icon): before, an OS-level click never reaches the page; after, the window comes forward and the click is delivered. Also verified a maximized window survives the tray round-trip maximized.
