### PR TITLE
Isolate desktop packaging to desktop tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
         include:
           - label: Windows x64
             runner: windows-latest
-            command: npm run pack:win
+            command: npm run build:openhome-sidecar -- --no-publish-development
           - label: Linux x64
             runner: ubuntu-latest
             command: npm run build:openhome-sidecar -- --no-publish-development
@@ -423,7 +423,7 @@ jobs:
     uses: ./.github/workflows/dsp.yml
     with:
       stage: windows
-      package_smoke: ${{ needs.scope.outputs.electron != 'true' }}
+      package_smoke: ${{ needs.scope.outputs.electron == 'true' }}
     permissions:
       contents: read
 

--- a/.github/workflows/dsp-library-release.yml
+++ b/.github/workflows/dsp-library-release.yml
@@ -334,10 +334,6 @@ jobs:
         run: |
           npm run test:dsp -- --native-build-type=Release
           node tools/dsp-parity/run.mjs --native
-      - name: Package Electron application
-        run: npm run pack:win
-      - name: Verify packaged DSP artifacts
-        run: npm run smoke:dsp-package
       - name: Build CPython 3.12 stable-ABI wheel
         uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:

--- a/tests/esm/ci-release-trigger-contract.test.mjs
+++ b/tests/esm/ci-release-trigger-contract.test.mjs
@@ -31,6 +31,10 @@ test('desktop and DSP Library release tags select only their owning workflows', 
 
   assert.match(desktopRelease, /^\s+- 'v\*'$/m);
   assert.match(dspLibraryRelease, /^\s+- 'dsp-v\*'$/m);
+  assert.doesNotMatch(
+    dspLibraryRelease,
+    /Package Electron application|electron-builder|pack:win|smoke:dsp-package/
+  );
 });
 
 test('central CI changes do not select unrelated product builds', () => {

--- a/tests/esm/openhome-windows-workflow-contract.test.mjs
+++ b/tests/esm/openhome-windows-workflow-contract.test.mjs
@@ -58,19 +58,22 @@ function jobBlock(workflow, jobName) {
   return lines.slice(start, nextJob < 0 ? lines.length : nextJob).join('\n');
 }
 
-test('Windows packaging workflows use the canonical OpenHome package verification path', () => {
+test('Windows desktop packaging is limited to the explicit Electron path', () => {
   const dspWindows = jobBlock(workflows.dsp, 'windows');
   const releaseWindows = jobBlock(workflows.release, 'windows');
-  for (const block of [dspWindows, releaseWindows]) {
-    assert.match(block, /^\s+run: npm run pack:win$/m);
-    assert.doesNotMatch(block, /^\s+run: npm run pack$/m);
-    assert.match(block, /^\s+run: npm run smoke:dsp-package$/m);
-  }
+  assert.match(dspWindows, /^\s+if: inputs\.package_smoke$/m);
+  assert.match(dspWindows, /^\s+run: npm run pack:win$/m);
+  assert.match(dspWindows, /^\s+run: npm run smoke:dsp-package$/m);
+  assert.doesNotMatch(releaseWindows, /pack:win|smoke:dsp-package|electron-builder/);
+
+  const dspWindowsCaller = jobBlock(workflows.ci, 'dsp-windows');
+  assert.match(dspWindowsCaller, /package_smoke: \$\{\{ needs\.scope\.outputs\.electron == 'true' \}\}/);
 
   const openHomeNative = jobBlock(workflows.ci, 'openhome-native');
   const install = openHomeNative.indexOf('run: npm ci --ignore-scripts');
   const execute = openHomeNative.indexOf('run: ${{ matrix.command }}');
-  assert.match(openHomeNative, /command: npm run pack:win/);
+  assert.match(openHomeNative, /runner: windows-latest\s+command: npm run build:openhome-sidecar -- --no-publish-development/);
+  assert.doesNotMatch(openHomeNative, /pack:win|electron-builder/);
   assert.ok(install >= 0 && execute > install, 'OpenHome CI must install before building and verification');
 });
 


### PR DESCRIPTION
## Summary

- remove Electron packaging from the DSP Library release workflow
- enable the DSP Core Windows package smoke only when the explicit desktop `v*` tag path selects Electron
- build the Windows OpenHome sidecar directly instead of packaging the Electron application
- add workflow contract coverage that keeps DSP Library releases free of desktop packaging

## Root cause

The DSP Library release workflow still ran `npm run pack:win`, and the central DSP Windows caller enabled package smoke when Electron was *not* selected. This allowed desktop packaging outside the explicit desktop tag path.

## Validation

- workflow contract tests (13 passed)
- `npm run verify`
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- staged diff check

The cancelled `dsp-v0.5.0` run did not publish to GitHub Releases, npm, or PyPI. The tag was removed and will be recreated on the corrected main commit after this PR passes.